### PR TITLE
Include disabled components and gameobjects when Validating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log:
+## 1.3.18
+- Fix: Now validator runs for disabled root gameobject's as well.
+
 ## 1.3.17
 - Fix: Group attributes would break if used with specific wrapper attributes. Fixed now.
 

--- a/Editor/Artifice_Validator/Artifice_ValidatorModule_SerializedPropertyBatching.cs
+++ b/Editor/Artifice_Validator/Artifice_ValidatorModule_SerializedPropertyBatching.cs
@@ -21,7 +21,7 @@ namespace ArtificeToolkit.Editor
                 if (gameObject == null)
                     continue;
                 
-                foreach (var component in gameObject.GetComponentsInChildren<Component>())
+                foreach (var component in gameObject.GetComponentsInChildren<Component>(true))
                 {
                     if(component == null)
                         continue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.abzorba.artificetoolkit",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "displayName": "Artifice Toolkit",
   "description": "ArtificeToolkit simplifies Unity editor customization by providing intuitive, easy-to-use custom attributes that can be applied directly in your source code. This toolkit allows developers to quickly and effortlessly enhance the look and behavior of Unity\u2019s inspector without requiring specialized knowledge of IMGUI or UI Toolkit libraries.\n\nBy using ArtificeToolkit, you can enhance the editor's functionality and customize property displays with minimal effort, reducing the need to maintain separate files or dive deep into complex editor programming.",
   "unity": "2022.3",


### PR DESCRIPTION
I noticed disabled game objects are skipped when validating a scene, so I came up with this fix because I have a number of gameobjects that must be disabled by default in my scenes.
I'm not sure if this behaviour is intented or not, feel free to dismiss this pull request if you do want to skip disabled game object from being validated.