### PR TITLE
Use Validor in a CI context

### DIFF
--- a/Editor/Artifice_Validator/Artifice_Validator.cs
+++ b/Editor/Artifice_Validator/Artifice_Validator.cs
@@ -315,6 +315,32 @@ namespace ArtificeToolkit.Editor
             _refreshCoroutine = EditorCoroutineUtility.StartCoroutine(RefreshLogsCoroutine(true), this);
         }
 
+        public List<ValidatorLog> RunSynchronousValidation()
+        {
+            if (_config == null) Initialize();
+
+            var allLogs = new List<ValidatorLog>();
+            
+            foreach (string sceneName in _config.scenesMap.Keys)
+            {
+                if (string.IsNullOrWhiteSpace(sceneName)) continue;
+                string[] guids = AssetDatabase.FindAssets("t:Scene " + sceneName);
+                if (guids.Length > 0)
+                {
+                    string scenePath = AssetDatabase.GUIDToAssetPath(guids[0]);
+                    EditorSceneManager.OpenScene(scenePath);
+
+                    var coroutine = RefreshLogsCoroutine(true);
+                    while (coroutine.MoveNext())
+                    {
+                    }
+                    allLogs.AddRange(_logs);
+                }
+            }
+
+            return allLogs;
+        }
+
         /// <summary> Iterates every nested property of gameobject to detect <see cref="ValidatorAttribute"/> and logs their validity. </summary>
         private IEnumerator RefreshLogsCoroutine(bool fullScan = false)
         {


### PR DESCRIPTION
Hello,
this is half-issue / half PR, wasn't sure on the way to go but since a I have code to suggest here I go.

# Issue

I found out there is no documentation about using Artifice validator in CI or build script, and since it relies on a hidden (private) coroutine it makes the exposed "RefreshLogs" method unusable in a synchronous build job.

## Context

We are using TeamCity as a CI and our build + validation work using unity in batch mode (https://docs.unity3d.com/2022.3/Documentation/Manual/EditorCommandLineArguments.html).

In this mode:
- TeamCity needs the method to resolve synchronously
- No scene is loaded by default in unity

So I needed a way to run validation synchronously and load scenes configured in validator.

Command looks like this (from project directory): `"C:\Program Files\Unity\Hub\Editor\2022.3.62f1\Editor\Unity.exe" -batchmode -projectPath ./ -executeMethod BuildUtilities.BuildAndroid -buildTarget android -quit -logFile buildlogs.txt` where BuildUtilities.BuildAndroid is an editor function that looks like :

```C#
[MenuItem("Build/Android")]
public static void BuildAndroid()
{
    // Build configuration
    var buildDirectory = "build/Android/";
    if (!Directory.Exists(buildDirectory)) Directory.CreateDirectory(buildDirectory);
    PlayerSettings.productName = "SuperApp";
    PlayerSettings.bundleVersion = "1.2.3";
    BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions();
    buildPlayerOptions.scenes = new[] { "Assets/Scenes/LoginScene.unity" };
    buildPlayerOptions.locationPathName = Path.Combine(buildDirectory, $"{PlayerSettings.productName}.apk");
    buildPlayerOptions.target = BuildTarget.Android;
    buildPlayerOptions.targetGroup = BuildTargetGroup.Android;
    buildPlayerOptions.options = BuildOptions.None;

    // Run validation
    var shouldBuild = RunValidation();
    if (!shouldBuild) return;

    // Run build
    BuildPipeline.BuildPlayer(buildPlayerOptions);
}
```

I wanted Artifice validator to be part of the `RunValidation` part, here how I got it work :

## Proposed solution

I created a synchronous method in Artifice_Validator called `RunSynchronousValidation` that load the scenes (only EditorSceneManager.OpenScene will work in editor batchmode) and compiles logs of each scene to send them back. See file changes for implementation.

Usage could look like this 

```C#
private static bool RunValidation()
{
    Debug.Log("[Validation] Starting validation");
    var logs = Artifice_Validator.Instance.RunSynchronousValidation();

    bool shouldBuild = true;
    foreach (var log in logs)
    {
        if (log.LogType is LogType.Assert)
        {
            Debug.LogAssertion(
                $"[Validation] [{log.OriginLocationName}] [{log.OriginObject}] {log.Message} ({log.OriginValidatorType.FullName})",
                log.OriginObject);
            shouldBuild = false;
        }
        else if (log.LogType is LogType.Error or LogType.Exception)
        {
            Debug.LogError(
                $"[Validation] [{log.OriginLocationName}] [{log.OriginObject}] {log.Message} ({log.OriginValidatorType.FullName})",
                log.OriginObject);
            shouldBuild = false;
        }
    }

    Debug.Log(shouldBuild ? "[Validation] Validation completed, all good." : "[Validation] Validation errors! Build should fail.");
    return shouldBuild;
}
```