### PR TITLE
Align Serialize Reference Dropdown

### DIFF
--- a/Editor/ArtificeDrawer.cs
+++ b/Editor/ArtificeDrawer.cs
@@ -380,12 +380,10 @@ namespace ArtificeToolkit.Editor
             selectorContainer.AddToClassList("serialize-reference-selector");
             container.Add(selectorContainer);
             
-            // Create label of property
-            var label = new Label(property.displayName);
-            selectorContainer.Add(label);
-
             // Create dropdown for selections.
             var dropdown = new DropdownField();
+            dropdown.AddToClassList(BaseField<object>.alignedFieldUssClassName);
+            dropdown.label = property.displayName;
             dropdown.choices.Add("Null");
             foreach (var pair in typeMap)
                 dropdown.choices.Add(pair.Key);


### PR DESCRIPTION
Serialize Reference Dropdown is aligned with the unity-inspector ui. I haven't tested this on any editor versions except Unity 6.3 Alpha (6000.3.0a3).

Before:
<img width="744" height="299" alt="image" src="https://github.com/user-attachments/assets/02a7c806-32fc-4d29-8892-b51542842d24" />


After:
<img width="746" height="270" alt="image" src="https://github.com/user-attachments/assets/6fd79315-2eda-4d6d-bdb8-c868d3d4a044" />