### PR TITLE
Add ValueDropdown Attribute & Drawer

### DIFF
--- a/Editor/Artifice_CustomAttributeDrawers/CustomAttributeDrawer_ValueDropdownDrawer.meta
+++ b/Editor/Artifice_CustomAttributeDrawers/CustomAttributeDrawer_ValueDropdownDrawer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 78566040bc6ae864598605ac904b54ca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Artifice_CustomAttributeDrawers/CustomAttributeDrawer_ValueDropdownDrawer/Artifice_CustomAttributeDrawer_OnValueChangedAttribute.cs
+++ b/Editor/Artifice_CustomAttributeDrawers/CustomAttributeDrawer_ValueDropdownDrawer/Artifice_CustomAttributeDrawer_OnValueChangedAttribute.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ArtificeToolkit.Attributes;
+using UnityEditor;
+using UnityEngine;
+
+namespace ArtificeToolkit.Editor.Artifice_CustomAttributeDrawers.CustomAttributeDrawer_ValueDropdownDrawer
+{
+    /// <summary>
+    /// Custom PropertyDrawer for <see cref="ValueDropdownAttribute"/>
+    /// </summary>
+    [CustomPropertyDrawer(typeof(ValueDropdownAttribute))]
+    public class ValueDropdownDrawer : PropertyDrawer
+    {
+        /// <summary>
+        /// Draw the property in the Inspector GUI
+        /// </summary>
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            if (property.propertyType != SerializedPropertyType.String)
+            {
+                EditorGUI.LabelField(position, label.text, "Use [ValueDropdown] with strings only.");
+                return;
+            }
+
+            // Get the attribute instance
+            ValueDropdownAttribute dropdownAttribute = (ValueDropdownAttribute)attribute;
+            object target = property.serializedObject.targetObject;
+            string memberName = dropdownAttribute.MethodName;
+
+            // Attempt to get the list of strings
+            List<string> stringList = GetListFromMember(target, memberName);
+
+            // Handle null or empty list
+            if (stringList == null || stringList.Count == 0)
+            {
+                EditorGUI.LabelField(position, label.text, $"Member '{memberName}' not found/empty.");
+                return;
+            }
+
+            // Determine the current index
+            int currentIndex = stringList.IndexOf(property.stringValue);
+
+            // Handle missing/custom values (e.g., if the string was set to something not in the list currently)
+            if (currentIndex == -1)
+            {
+                if (!string.IsNullOrEmpty(property.stringValue))
+                {
+                    stringList.Insert(0, $"{property.stringValue} (Current)");
+                    currentIndex = 0;
+                }
+                else
+                {
+                    currentIndex = 0;
+                }
+            }
+
+            // Draw the Popup
+            EditorGUI.BeginChangeCheck();
+            int newIndex = EditorGUI.Popup(position, label.text, currentIndex, stringList.ToArray());
+
+            // Apply changes if selection changed
+            if (EditorGUI.EndChangeCheck())
+            {
+                if (newIndex >= 0 && newIndex < stringList.Count)
+                {
+                    string selection = stringList[newIndex];
+                    // Remove the temporary visual tag if selected
+                    if (selection.EndsWith(" (Current)"))
+                    {
+                        selection = selection.Replace(" (Current)", "");
+                    }
+                    property.stringValue = selection;
+                    property.serializedObject.ApplyModifiedProperties();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tries to find a Field, Property, or Method that returns IEnumerable<string>
+        /// </summary>
+        private List<string> GetListFromMember(object target, string memberName)
+        {
+            System.Type type = target.GetType();
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+            object rawValue = null;
+
+            // Try getting Field
+            FieldInfo field = type.GetField(memberName, flags);
+            if (field != null)
+            {
+                rawValue = field.GetValue(target);
+            }
+            else
+            {
+                // Try getting Property
+                PropertyInfo prop = type.GetProperty(memberName, flags);
+                if (prop != null)
+                {
+                    rawValue = prop.GetValue(target, null);
+                }
+                // Try getting Method
+                else
+                {
+                    MethodInfo method = type.GetMethod(memberName, flags);
+                    if (method != null)
+                    {
+                        rawValue = method.Invoke(target, null);
+                    }
+                }
+            }
+
+            // Convert the result to List<string> safely
+            if (rawValue is IEnumerable<string> enumerable)
+            {
+                return enumerable.ToList();
+            }
+
+            // If we reach here, we failed to get a valid list, so return null
+            return null;
+        }
+    }
+}

--- a/Editor/Artifice_CustomAttributeDrawers/CustomAttributeDrawer_ValueDropdownDrawer/Artifice_CustomAttributeDrawer_OnValueChangedAttribute.cs
+++ b/Editor/Artifice_CustomAttributeDrawers/CustomAttributeDrawer_ValueDropdownDrawer/Artifice_CustomAttributeDrawer_OnValueChangedAttribute.cs
@@ -18,69 +18,101 @@ namespace ArtificeToolkit.Editor.Artifice_CustomAttributeDrawers.CustomAttribute
         /// </summary>
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            if (property.propertyType != SerializedPropertyType.String)
-            {
-                EditorGUI.LabelField(position, label.text, "Use [ValueDropdown] with strings only.");
-                return;
-            }
-
             // Get the attribute instance
             ValueDropdownAttribute dropdownAttribute = (ValueDropdownAttribute)attribute;
             object target = property.serializedObject.targetObject;
             string memberName = dropdownAttribute.MethodName;
 
-            // Attempt to get the list of strings
-            List<string> stringList = GetListFromMember(target, memberName);
-
-            // Handle null or empty list
-            if (stringList == null || stringList.Count == 0)
+            // Get the field type
+            var fieldType = GetFieldType(property);
+            var options = GetListFromMember(target, memberName, fieldType);
+            if (options == null || options.Count == 0)
             {
                 EditorGUI.LabelField(position, label.text, $"Member '{memberName}' not found/empty.");
                 return;
             }
 
-            // Determine the current index
-            int currentIndex = stringList.IndexOf(property.stringValue);
-
-            // Handle missing/custom values (e.g., if the string was set to something not in the list currently)
-            if (currentIndex == -1)
+            // Convert options to display names and find current index
+            int currentIndex = 0;
+            object currentValue = GetPropertyValue(property);
+            var displayNames = options.Select(o => o?.ToString() ?? "<null>").ToArray();
+            for (int i = 0; i < options.Count; i++)
             {
-                if (!string.IsNullOrEmpty(property.stringValue))
+                if ((currentValue == null && options[i] == null) || (currentValue != null && currentValue.Equals(options[i])))
                 {
-                    stringList.Insert(0, $"{property.stringValue} (Current)");
-                    currentIndex = 0;
-                }
-                else
-                {
-                    currentIndex = 0;
+                    currentIndex = i;
+                    break;
                 }
             }
 
-            // Draw the Popup
             EditorGUI.BeginChangeCheck();
-            int newIndex = EditorGUI.Popup(position, label.text, currentIndex, stringList.ToArray());
-
-            // Apply changes if selection changed
+            int newIndex = EditorGUI.Popup(position, label.text, currentIndex, displayNames);
             if (EditorGUI.EndChangeCheck())
             {
-                if (newIndex >= 0 && newIndex < stringList.Count)
+                if (newIndex >= 0 && newIndex < options.Count)
                 {
-                    string selection = stringList[newIndex];
-                    // Remove the temporary visual tag if selected
-                    if (selection.EndsWith(" (Current)"))
-                    {
-                        selection = selection.Replace(" (Current)", "");
-                    }
-                    property.stringValue = selection;
+                    SetPropertyValue(property, options[newIndex]);
                     property.serializedObject.ApplyModifiedProperties();
                 }
             }
         }
 
+        private System.Type GetFieldType(SerializedProperty property)
+        {
+            var parent = property.serializedObject.targetObject.GetType();
+            var field = parent.GetField(property.name, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            return field != null ? field.FieldType : typeof(string);
+        }
+
+        private object GetPropertyValue(SerializedProperty property)
+        {
+            switch (property.propertyType)
+            {
+                case SerializedPropertyType.Integer:
+                    return property.intValue;
+                case SerializedPropertyType.Boolean:
+                    return property.boolValue;
+                case SerializedPropertyType.Float:
+                    return property.floatValue;
+                case SerializedPropertyType.String:
+                    return property.stringValue;
+                case SerializedPropertyType.Enum:
+                    return property.enumNames.Length > 0 ? property.enumNames[property.enumValueIndex] : null;
+                default:
+                    return null;
+            }
+        }
+
+        private void SetPropertyValue(SerializedProperty property, object value)
+        {
+            switch (property.propertyType)
+            {
+                case SerializedPropertyType.Integer:
+                    property.intValue = value is int i ? i : 0;
+                    break;
+                case SerializedPropertyType.Boolean:
+                    property.boolValue = value is bool b && b;
+                    break;
+                case SerializedPropertyType.Float:
+                    property.floatValue = value is float f ? f : 0f;
+                    break;
+                case SerializedPropertyType.String:
+                    property.stringValue = value?.ToString() ?? string.Empty;
+                    break;
+                case SerializedPropertyType.Enum:
+                    if (value != null)
+                    {
+                        var idx = System.Array.IndexOf(property.enumNames, value.ToString());
+                        if (idx >= 0) property.enumValueIndex = idx;
+                    }
+                    break;
+            }
+        }
+
         /// <summary>
-        /// Tries to find a Field, Property, or Method that returns IEnumerable<string>
+        /// Tries to find a Field, Property, or Method that returns IEnumerable<T>, T[], or a single T for the dropdown.
         /// </summary>
-        private List<string> GetListFromMember(object target, string memberName)
+        private List<object> GetListFromMember(object target, string memberName, System.Type fieldType)
         {
             System.Type type = target.GetType();
             BindingFlags flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
@@ -111,13 +143,27 @@ namespace ArtificeToolkit.Editor.Artifice_CustomAttributeDrawers.CustomAttribute
                 }
             }
 
-            // Convert the result to List<string> safely
-            if (rawValue is IEnumerable<string> enumerable)
+            if (rawValue == null)
+                return null;
+
+            // Handle arrays and IEnumerable<T>
+            if (rawValue is System.Collections.IEnumerable enumerable && !(rawValue is string))
             {
-                return enumerable.ToList();
+                var list = new List<object>();
+                foreach (var item in enumerable)
+                {
+                    if (item == null || fieldType.IsAssignableFrom(item.GetType()) || item.GetType().IsPrimitive || item is string)
+                        list.Add(item);
+                }
+                return list;
             }
 
-            // If we reach here, we failed to get a valid list, so return null
+            // Handle single value
+            if (fieldType.IsAssignableFrom(rawValue.GetType()) || rawValue.GetType().IsPrimitive || rawValue is string)
+            {
+                return new List<object> { rawValue };
+            }
+
             return null;
         }
     }

--- a/Editor/Artifice_CustomAttributeDrawers/CustomAttributeDrawer_ValueDropdownDrawer/Artifice_CustomAttributeDrawer_OnValueChangedAttribute.cs.meta
+++ b/Editor/Artifice_CustomAttributeDrawers/CustomAttributeDrawer_ValueDropdownDrawer/Artifice_CustomAttributeDrawer_OnValueChangedAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a4c0d604cd52c7b49b3032f702ab1912

--- a/Runtime/CustomAttributes/ValueDropdownAttribute.cs
+++ b/Runtime/CustomAttributes/ValueDropdownAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+using UnityEngine;
+
+namespace ArtificeToolkit.Attributes
+{
+    /// <summary>
+    /// Attribute to specify that a string field should present a dropdown list of values
+    /// retrieved from a specified method, property, or field.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class ValueDropdownAttribute : PropertyAttribute
+    {
+        public string MethodName { get; private set; }
+
+        public ValueDropdownAttribute(string methodName)
+        {
+            MethodName = methodName;
+        }
+    }
+}

--- a/Runtime/CustomAttributes/ValueDropdownAttribute.cs.meta
+++ b/Runtime/CustomAttributes/ValueDropdownAttribute.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5ed29a8061a7870469c999da91cd4d3c


### PR DESCRIPTION
# ValueDropdown Attribute & Drawer

The `ValueDropdownAttribute` and its associated PropertyDrawer provide a convenient way to present a field as a dropdown in the Unity Inspector, with options dynamically sourced from your code. As of the latest version, this supports not only `string` fields, but also `int`, `float`, `bool`, `enum`, and other primitive types.

---

<img width="515" height="183" alt="image" src="https://github.com/user-attachments/assets/db651da2-59b2-429d-9d69-9abc2e319d64" />

## Overview

- **Attribute:** `ValueDropdownAttribute` (place on supported fields)
- **Drawer:** `ValueDropdownDrawer` (automatically used in the Unity Editor)
- **Purpose:** Show a dropdown for fields (string, int, float, enum, etc.), with options provided by a method, property, or field on the same object. The dropdown adapts to the field type.

---

## Usage Example


```csharp
using ArtificeToolkit.Attributes;
using UnityEngine;
using System.Collections.Generic;

public class Example : MonoBehaviour
{
    // Dropdown for color selection (string)
    [ValueDropdown("ColorOptions")]
    public string selectedColor;
    private string[] ColorOptions = new[] { "Red", "Green", "Blue" };

    // Dropdown for number selection (int)
    [ValueDropdown("AvailableNumbers")]
    public int selectedNumber;
    private List<int> AvailableNumbers => new List<int> { 1, 2, 3, 4 };

    // Dropdown for float value selection
    [ValueDropdown("AvailableSpeeds")]
    public float selectedSpeed;
    private float[] AvailableSpeeds = { 0.5f, 1.0f, 2.5f };

    // Dropdown for enum selection
    [ValueDropdown("AnimalOptions")]
    public Animal selectedAnimal;
    private Animal[] AnimalOptions = { Animal.Dog, Animal.Cat, Animal.Bird };

    // Dropdown for boolean value selection
    [ValueDropdown("ValueOptions")]
    public bool selectedValue;
    private bool[] ValueOptions = { true, false };

    // Dropdown from a method returning a single value (not recommended, but supported)
    [ValueDropdown("SingleLuckyNumber")]
    public int luckyNumber;
    private int SingleLuckyNumber() => 7;
}

public enum Animal { Dog, Cat, Bird }
```

- The dropdown will display the values provided by the referenced member.
- The member can be a method, property, or field, and may return or provide `IEnumerable<T>`, `T[]`, or a single value of the field type.

---

## How It Works

- The attribute takes the name of a member (method/property/field) as a string.
- At runtime, the drawer uses reflection to find and invoke this member.
- The returned list populates the dropdown in the Inspector.
- Works for fields of type `string`, `int`, `float`, `bool`, `enum`, and other primitives. The dropdown adapts to the field type and displays the available options accordingly.

---

## Attribute Reference

### `ValueDropdownAttribute`

| Parameter   | Description                                                                 |
|-------------|-----------------------------------------------------------------------------|
| methodName  | The name of the method, property, or field that provides the dropdown list. |

---

## Drawer Details

- The drawer will show a warning if the provider member cannot be found or returns no values.
- If the current value is not in the list, it will be shown as `(Current)` at the top (for string fields).
- For enums, the dropdown displays the enum names.
- For bool, the dropdown displays true/false.

---

## Best Practices

- The member providing the list can be private or public.
- Use unique names for dropdown providers to avoid ambiguity.
- The dropdown list is refreshed each time the Inspector is drawn.

---

## Limitations (?)

- Supports string, int, float, bool, enum, and other primitive fields.
- The provider must return or expose `IEnumerable<T>`, `T[]`, or a single value of the field type.
- Complex types (e.g., custom classes, structs) are not supported unless they override `ToString()` meaningfully.

>These limitations are effect of the intentional design of the extension, so they are not really limitations.
---

## License

See [Assets/artificetoolkit/LICENSE](../LICENSE)

---

## See Also
- `ValueDropdownAttribute` source: `Assets/artificetoolkit/Runtime/CustomAttributes/ValueDropdownAttribute.cs`
- Drawer source: `Assets/artificetoolkit/Editor/Artifice_CustomAttributeDrawers/CustomAttributeDrawer_ValueDropdownDrawer/Artifice_CustomAttributeDrawer_OnValueChangedAttribute.cs`
