### PR TITLE
Add menu item to refresh Artifice inspector styles

### DIFF
--- a/Editor/ArtificeInspector.cs
+++ b/Editor/ArtificeInspector.cs
@@ -15,8 +15,7 @@ namespace ArtificeToolkit.Editor
     public class ArtificeInspector : UnityEditor.Editor
     {
         #region FIELDS
-    
-
+        
         private ArtificeDrawer _drawer;
 
         #endregion


### PR DESCRIPTION
# Artifice Debug Feature: Refresh Styles

## Overview
The **Refresh Styles** functionality in Artifice Toolkit provides a convenient way to force the Unity Editor to reload all USS (Unity Style Sheets) stylesheets used by Artifice custom inspectors. This is especially useful when developing or tweaking custom USS files for inspector UI, as it allows you to see style changes immediately without restarting the Unity Editor.

## Why it is needed
It is very usefull for debug reasons, when fixing the Artifice Toolkit issues, to just click and refresh the script being repaired instead of removing it and adding again to preview the fix of the style. This saves a lot of time and speeds up the process of fixing the reported issues.

## How to Use
- **Right-click** on any object in the Unity Inspector.
- Navigate to: `Artifice Debug > Refresh Styles` in the context menu.
- Click **Refresh Styles**.

This will trigger a repaint of all Inspector windows and clear any cached Artifice styles, ensuring that the latest USS changes are applied.

## When to Use
- After editing any `.uss` file used by Artifice custom inspectors.
- When styles appear out of date or do not reflect recent changes.
- During development of new Artifice inspector UI features.

## Technical Details
- The menu item is registered via `[MenuItem("CONTEXT/Object/Artifice Debug/Refresh Styles")]` in `ArtificeInspector.cs`.
- The method repaints all open Inspector windows and calls `Artifice_Utilities.TriggerNextFrameReselection()` to clear style caches.

## Troubleshooting
- If styles do not update after using this feature, ensure your USS file is saved and correctly referenced in the inspector code.
- For persistent issues, try closing and reopening the Inspector window or restarting the Unity Editor.

---
*This feature is intended for editor-time debugging and development only. It does not affect runtime styling or builds.*
